### PR TITLE
remove 'capture_output'

### DIFF
--- a/kubecargoload.py
+++ b/kubecargoload.py
@@ -74,7 +74,11 @@ class KubernetesCargoLoadOverviewProvider:
             command.append(self._namespace)
 
         try:
-            process = subprocess.run(command, capture_output=True, check=True)
+            process = subprocess.run(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True)
         except subprocess.CalledProcessError as exc:
             print(exc.stderr.decode('utf-8'))
             raise


### PR DESCRIPTION
capture_output was introduced in 3.7, older versions won't work.